### PR TITLE
Remove unnecessary syntax and invalid comments

### DIFF
--- a/src/MessagingServiceEmulator/GetSimulatedDataModel.lua
+++ b/src/MessagingServiceEmulator/GetSimulatedDataModel.lua
@@ -60,8 +60,8 @@ return function()
 
         See documentation for [DataModel:IsLoaded]
     ]=]
-    function SimulatedDataModel:IsLoaded(...)
-        return game:IsLoaded(...) --// This method doesn't take arguments, so this neither hurts or really does anything :/
+    function SimulatedDataModel:IsLoaded()
+        return game:IsLoaded() --// Method doesn't take arguments
     end
 
     --[=[
@@ -71,7 +71,7 @@ return function()
         See documentation for [DataModel:SetPlaceId]
     ]=]
     function SimulatedDataModel:SetPlaceId(...)
-        return game:SetPlaceId(...) --// This method doesn't take arguments, so this neither hurts or really does anything :/
+        return game:SetPlaceId(...)
     end
 
     --[=[
@@ -81,7 +81,7 @@ return function()
         See documentation for [DataModel:SetUniverseId]
     ]=]
     function SimulatedDataModel:SetUniverseId(...)
-        return game:SetUniverseId(...) --// This method doesn't take arguments, so this neither hurts or really does anything :/
+        return game:SetUniverseId(...)
     end
 
     --// ServiceProvider methods
@@ -93,7 +93,7 @@ return function()
         See documentation for [DataModel:FindService]
     ]=]
     function SimulatedDataModel:FindService(...)
-        return game:FindService(...) --// This method doesn't take arguments, so this neither hurts or really does anything :/
+        return game:FindService(...)
     end
 
     --[=[
@@ -103,7 +103,7 @@ return function()
         See documentation for [DataModel:GetService]
     ]=]
     function SimulatedDataModel:GetService(...)
-        return game:GetService(...) --// This method doesn't take arguments, so this neither hurts or really does anything :/
+        return game:GetService(...)
     end
 
     --// Custom methods
@@ -120,9 +120,7 @@ return function()
 
     setmetatable(SimulatedDataModel, {
         __index = function(Table, Index) --// Used for retrieving/reading game properties
-            local ActualDataModel = workspace.Parent
-
-            return ActualDataModel[Index]
+            return game[Index]
         end,
     })
 

--- a/src/MessagingServiceEmulator/GetSimulatedDataModel.lua
+++ b/src/MessagingServiceEmulator/GetSimulatedDataModel.lua
@@ -31,9 +31,7 @@ return function()
         See documentation for [DataModel:BindToClose]
     ]=]
     function SimulatedDataModel:BindToClose(...)
-        local Arguments = {...}
-
-        SimulateCloseSignal:Connect(table.unpack(Arguments)) --// Simulates BindToClose
+        SimulateCloseSignal:Connect(...) --// Simulates BindToClose
     end
 
     --[=[
@@ -42,10 +40,8 @@ return function()
 
         See documentation for [DataModel:GetJobsInfo]
     ]=]
-    function SimulatedDataModel:GetJobsInfo(...)
-        local Arguments = {...}
-
-        return game:GetJobsInfo(table.unpack(Arguments)) --// This method doesn't take arguments, so this neither hurts or really does anything :/
+    function SimulatedDataModel:GetJobsInfo()
+        return game:GetJobsInfo() --// Method doesn't take arguments
     end
 
     --[=[
@@ -55,9 +51,7 @@ return function()
         See documentation for [DataModel:GetObjects]
     ]=]
     function SimulatedDataModel:GetObjects(...)
-        local Arguments = {...}
-
-        return game:GetObjects(table.unpack(Arguments)) --// This method doesn't take arguments, so this neither hurts or really does anything :/
+        return game:GetObjects(...)
     end
 
     --[=[
@@ -67,9 +61,7 @@ return function()
         See documentation for [DataModel:IsLoaded]
     ]=]
     function SimulatedDataModel:IsLoaded(...)
-        local Arguments = {...}
-
-        return game:IsLoaded(table.unpack(Arguments)) --// This method doesn't take arguments, so this neither hurts or really does anything :/
+        return game:IsLoaded(...) --// This method doesn't take arguments, so this neither hurts or really does anything :/
     end
 
     --[=[
@@ -79,9 +71,7 @@ return function()
         See documentation for [DataModel:SetPlaceId]
     ]=]
     function SimulatedDataModel:SetPlaceId(...)
-        local Arguments = {...}
-
-        return game:SetPlaceId(table.unpack(Arguments)) --// This method doesn't take arguments, so this neither hurts or really does anything :/
+        return game:SetPlaceId(...) --// This method doesn't take arguments, so this neither hurts or really does anything :/
     end
 
     --[=[
@@ -91,9 +81,7 @@ return function()
         See documentation for [DataModel:SetUniverseId]
     ]=]
     function SimulatedDataModel:SetUniverseId(...)
-        local Arguments = {...}
-
-        return game:SetUniverseId(table.unpack(Arguments)) --// This method doesn't take arguments, so this neither hurts or really does anything :/
+        return game:SetUniverseId(...) --// This method doesn't take arguments, so this neither hurts or really does anything :/
     end
 
     --// ServiceProvider methods
@@ -105,9 +93,7 @@ return function()
         See documentation for [DataModel:FindService]
     ]=]
     function SimulatedDataModel:FindService(...)
-        local Arguments = {...}
-
-        return game:FindService(table.unpack(Arguments)) --// This method doesn't take arguments, so this neither hurts or really does anything :/
+        return game:FindService(...) --// This method doesn't take arguments, so this neither hurts or really does anything :/
     end
 
     --[=[
@@ -117,9 +103,7 @@ return function()
         See documentation for [DataModel:GetService]
     ]=]
     function SimulatedDataModel:GetService(...)
-        local Arguments = {...}
-
-        return game:GetService(table.unpack(Arguments)) --// This method doesn't take arguments, so this neither hurts or really does anything :/
+        return game:GetService(...) --// This method doesn't take arguments, so this neither hurts or really does anything :/
     end
 
     --// Custom methods
@@ -130,7 +114,7 @@ return function()
 
         Simulates the DataModel closing and fires all functions bound via [SimulatedDataModel:BindToClose]
     ]=]
-    function SimulatedDataModel:SimulateClose(...)
+    function SimulatedDataModel:SimulateClose()
         SimulateCloseSignal:Fire()
     end
 


### PR DESCRIPTION
Removed several varargs in ``src/MessagingServiceEmulator/GetSimulatedDataModel.lua`` for functions that don't take any arguments.